### PR TITLE
Minor fix.

### DIFF
--- a/recipes/ner.py
+++ b/recipes/ner.py
@@ -253,7 +253,7 @@ def ner_openai_correct(
     max_examples=("Max examples to include in prompt", "option", "n", int),
     prompt_path=("Path to jinja2 prompt template", "option", "p", Path),
     batch_size=("Batch size to send to OpenAI API", "option", "b", int),
-    verbose=("Print extra information to terminal", "option", "v", bool),
+    verbose=("Print extra information to terminal", "option", "flag", bool),
 )
 def ner_openai_fetch(
     input_path: Path,


### PR DESCRIPTION
When running this: 

```
python -m prodigy ner.openai.correct fashion-openai examples.jsonl "brand,clothing" -F recipes/ner.py
```

I got this error: 

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/vincent/Development/prodigy-demos/venv/lib/python3.8/site-packages/prodigy/__main__.py", line 61, in <module>
    controller = recipe(*args, use_plac=True)
  File "cython_src/prodigy/core.pyx", line 329, in prodigy.core.recipe.recipe_decorator.recipe_proxy
  File "/home/vincent/Development/prodigy-demos/venv/lib/python3.8/site-packages/plac_core.py", line 367, in call
    cmd, result = parser.consume(arglist)
  File "/home/vincent/Development/prodigy-demos/venv/lib/python3.8/site-packages/plac_core.py", line 232, in consume
    return cmd, self.func(*(args + varargs + extraopts), **kwargs)
  File "recipes/ner.py", line 224, in ner_openai_correct
    for eg in db.get_dataset(dataset):
```

It seems `db.get_dataset(dataset)` doesn't return an empty list but `None`. Made a fix to ensure a new dataset doesn't cause errors. 