### PR TITLE
Handle multiple mentions correctly

### DIFF
--- a/recipes/ner.py
+++ b/recipes/ner.py
@@ -376,10 +376,10 @@ def _find_substrings(
 
 
 def test_multiple_substrings():
-    text = "The Blargs is the debut album by The Blargs."
-    substrings = ["The Blargs"]
+    text = "The Blargs is the debut album by rock band The Blargs."
+    substrings = ["The Blargs", "rock"]
     res = _find_substrings(text, substrings)
-    assert len(res) == 2, "Didn't find the right number of occurrences"
+    assert len(res) == 3, "Didn't find the right number of occurrences"
 
 
 def test_template_no_examples():


### PR DESCRIPTION
Small fix to the substring detection. 

Substring detection was designed with the assumption that there would be one instance per item, and that they would be in order. But that isn't the case in practice - each entity is only mentioned once in the output, even if I show examples with multiple instances. 

The one-mention-per-occurrence assumption meant that if you had entities A and B, and the text was like "A B A", it would miss B because it was looking after the second A. This PR fixes that. 

Looking at this, it also looks like while each label checks substrings independently, that means that weird things would have happened before this PR if one string could be two entity types. For my test application with Albums and Tracks that's pretty common. 