### PR TITLE
Fixing flagged examples

### DIFF
--- a/recipes/ner.py
+++ b/recipes/ner.py
@@ -89,6 +89,7 @@ class OpenAISuggester:
             if example.get("answer", "") == "accept":
                 example = self._convert_from_prodigy_format(example)
                 # Note that this really shouldn't happen - it'll make Prodigy give a "could not save annotations" warning
+                # But if we don't assert, we get a silent failure.
                 assert "text" in example.keys()
                 assert "entities" in example.keys()
                 self.examples.append(example)
@@ -101,7 +102,7 @@ class OpenAISuggester:
         full_text = example["text"]
         for span in example.get("spans", []):
             label = span["label"]
-            mention = full_text[int(span["start"]):int(span["end"])]
+            mention = full_text[int(span["start"]) : int(span["end"])]
             l_list = entities_by_label.get(label, [])
             l_list.append(mention)
             entities_by_label[label] = l_list


### PR DESCRIPTION
When an example gets flagged, it's passed to the `OpenAISuggester` and added to its `self.examples`. However, the format / dict structure of the latter is different than the original dict from Prodigy, so we need a conversion function.

From first tests this seems to work, as before this PR the verbose option would show only the `text` of the flagged example in the prompt, and no annotations. Now at least it also shows the annotation:

```
| For example:                                                                |
|                                                                             |
| Text:                                                                       |
| """                                                                         |
| Cream cheese is an industrial product and can't be made in the home         |
| kitchen.                                                                    |
| """                                                                         |
| ingredient: Cream cheese  
```

I haven't been able to test this fully yet though, so putting in draft for now.