### PR TITLE
add senter only when segmenting

### DIFF
--- a/openai-ner/recipes/openai_ner.py
+++ b/openai-ner/recipes/openai_ner.py
@@ -274,7 +274,7 @@ def ner_openai_correct(
 ):
     examples = _read_prompt_examples(examples_path)
     nlp = spacy.blank(lang)
-    if not segment:
+    if segment:
         nlp.add_pipe("sentencizer")
     api_key, api_org = _get_api_credentials()
     openai = OpenAISuggester(


### PR DESCRIPTION
This bug crept in with https://github.com/explosion/openai-prodigy-recipes/commit/bc685d9db40fd10c7834c0704790effe731bc189: the `sentencizer` should be added when you're segmenting into sentences.
