### PR TITLE
Show prompt/response boxes

### DIFF
--- a/openai-ner/recipes/openai_ner.py
+++ b/openai-ner/recipes/openai_ner.py
@@ -106,6 +106,8 @@ class OpenAISuggester:
         self.openai_max_tokens = openai_max_tokens
         self.openai_timeout_s = openai_timeout_s
         self.openai_n = openai_n
+        # sanity check for API access and model availability.
+        self._ensure_valid_access()
 
     def __call__(
         self, stream: Iterable[Dict], *, nlp: Language, batch_size: int
@@ -277,7 +279,7 @@ def ner_openai_correct(
 ):
     examples = _read_prompt_examples(examples_path)
     nlp = spacy.blank(lang)
-    if segment:
+    if not segment:
         nlp.add_pipe("sentencizer")
     api_key, api_org = _get_api_credentials()
     openai = OpenAISuggester(


### PR DESCRIPTION
Add back information on the raw prompt and response, which I think is pretty cool to see right from within Prodigy!
I started zero-shot and then flagged two cases, which then nicely show up (though only some time later in the stream, which can confuse users, but not sure there's an easy fix for that)

