### PR TITLE
flag needs to be `False` by default

### DIFF
--- a/openai-ner/recipes/openai_ner.py
+++ b/openai-ner/recipes/openai_ner.py
@@ -332,7 +332,7 @@ def ner_openai_fetch(
     lang: str = "en",
     model: str = "text-davinci-003",
     batch_size: int = 10,
-    segment: bool = True,
+    segment: bool = False,
     examples_path: Optional[Path] = None,
     prompt_path: Path = DEFAULT_PROMPT_PATH,
     max_examples: int = 2,


### PR DESCRIPTION
Even after the [renaming](https://github.com/explosion/openai-prodigy-recipes/commit/bc685d9db40fd10c7834c0704790effe731bc189), the `segment` flag needs to be `False` by default in, right? Otherwise there's no way the user can actually set this functionality off?  
It's set to `False` by default for `ner.openai.correct` but not for `ner.openai.fetch` - fixing in this PR.