### PR TITLE
HF Training Cleanup

### DIFF
--- a/scripts/train_hf_ner.py
+++ b/scripts/train_hf_ner.py
@@ -161,6 +161,6 @@ def train_hf_ner(infile: str, outdir: str, base: str = "distilbert-base-uncased"
 
 
 if __name__ == "__main__":
-    app = typer.Typer(name="Convert spaCy to HF NER data", no_args_is_help=True)
+    app = typer.Typer(name="Train a HuggingFace NER model from spaCy formatted data", no_args_is_help=True)
     app.command("train_hf_ner")(train_hf_ner)
     app()


### PR DESCRIPTION
This is for various cleanup on the HF training script. 

1. Turn off tqdm. The output is a mess because every epoch includes newlines, so it's best to disable it.
2. The default optimizer is deprecated for the default model we're using, so this changes it to the suggested replacement. 

More notes in a second...