### PR TITLE
Use json formatting instead of csv for NER output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ to the language model the type of predictions we want. Something like:
 
 ```
 From the text below, extract the following entities in the following format:
-dish: <comma delimited list of strings>
-ingredient: <comma delimited list of strings>
-equipment: <comma delimited list of strings>
+dish: <JSON list of strings>
+ingredient: <JSON list of strings>
+equipment: <JSON list of strings>
 
 Text:
 ...

--- a/recipes/openai_ner.py
+++ b/recipes/openai_ner.py
@@ -253,7 +253,7 @@ class OpenAISuggester:
     def parse_response(cls, text: str) -> List[Tuple[str, List[str]]]:
         """Interpret OpenAI's NER response. It's supposed to be
         a list of lines, with each line having the form:
-        Label: phrase1, phrase2, ...
+        Label: ["phrase1", "phrase2"]
 
         However, there's no guarantee that the model will give
         us well-formed output. It could say anything, it's an LM.

--- a/templates/ner_prompt.jinja2
+++ b/templates/ner_prompt.jinja2
@@ -1,7 +1,7 @@
 From the text below, extract the following entities in the following format:
 {# whitespace #}
 {%- for label in labels -%}
-{{label}}: <comma delimited list of strings>
+{{label}}: <JSON list of strings>
 {# whitespace #}
 {%- endfor -%}
 {# whitespace #}
@@ -22,7 +22,7 @@ Text:
 """
 {# whitespace #}
 {%- for label, substrings in example.entities.items() -%}
-{{ label }}: {{ ", ".join(substrings) }}
+{{ label }}: {{ substrings | tojson }}
 {# whitespace #}
 {%- endfor -%}
 {# whitespace #}

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -43,9 +44,9 @@ def test_template_no_examples():
         prompt
         == f"""
 From the text below, extract the following entities in the following format:
-PERSON: <comma delimited list of strings>
-PLACE: <comma delimited list of strings>
-PERIOD: <comma delimited list of strings>
+PERSON: <JSON list of strings>
+PLACE: <JSON list of strings>
+PERIOD: <JSON list of strings>
 
 Text:
 \"\"\"
@@ -77,9 +78,9 @@ def test_template_two_examples():
         prompt
         == f"""
 From the text below, extract the following entities in the following format:
-PERSON: <comma delimited list of strings>
-PLACE: <comma delimited list of strings>
-PERIOD: <comma delimited list of strings>
+PERSON: <JSON list of strings>
+PLACE: <JSON list of strings>
+PERIOD: <JSON list of strings>
 
 Text:
 \"\"\"
@@ -92,14 +93,14 @@ Text:
 \"\"\"
 New York is a large city.
 \"\"\"
-PLACE: New York
+PLACE: ["New York"]
 
 Text:
 \"\"\"
 David Hasslehoff and Helena Fischer are big in Germany.
 \"\"\"
-PERSON: David Hasslehoff, Helena Fischer
-PLACE: Germany
+PERSON: ["David Hasslehoff", "Helena Fischer"]
+PLACE: ["Germany"]
 
 """.lstrip()
     )
@@ -169,7 +170,7 @@ def _get_response(text: str, labels, spans: List[Tuple[str, int, int]]) -> str:
         spans_by_label[label].append(text[start_chars[start] : end_chars[end - 1]])
     response_lines = []
     for label in labels:
-        response_lines.append(f"{label}: {', '.join(spans_by_label[label])}")
+        response_lines.append(f"{label}: {json.dumps(spans_by_label[label])}")
     return "\n".join(response_lines)
 
 


### PR DESCRIPTION
Entity spans containing commas (e.g. money amounts, `$100,000`) often cause the model to output invalid comma-separated lists. As a workaround, I tried requesting JSON formatting using the prompt `label: <JSON list of strings>`. This turns out to work really well, even for entities containing quotes (which are backslash-escaped in the output!)

- [ ] What to do in case of invalid JSON output? (haven't seen this yet) Currently I'm raising an OutputParseError, but if we expect this to happen we might want to log it and skip the entity.
- [ ] Should this be implemented as a response parser from PR #55? (Note: the prompt also needs to be modified)
